### PR TITLE
Auth patches

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -122,9 +122,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL {
   // rejects URLs that don't match redirect (these may be completely unrelated to the authorization)
-  if (![self shouldHandleURL:URL]) {
-    return NO;
-  }
+  // if (![self shouldHandleURL:URL]) {
+  //   return NO;
+  // }
   
   AppAuthRequestTrace(@"Authorization Response: %@", URL);
   

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -253,6 +253,12 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   if (_codeVerifier) {
     [query addParameter:kCodeVerifierKey value:_codeVerifier];
   }
+  if (_clientID) {
+    [query addParameter:kClientIDKey value:_clientID];
+  }
+  if (_clientSecret) {
+    [query addParameter:kClientSecretKey value:_clientSecret];
+  }
 
   // Add any additional parameters the client has specified.
   [query addParameters:_additionalParameters];

--- a/Source/OIDURLQueryComponent.m
+++ b/Source/OIDURLQueryComponent.m
@@ -46,8 +46,17 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
     if (@available(iOS 8.0, macOS 10.10, *)) {
       // If NSURLQueryItem is available, use it for deconstructing the new URL. (iOS 8+)
       if (!gOIDURLQueryComponentForceIOS7Handling) {
+        // The URL may need to be fixed before we can extract the components correctly.
+        NSURL *fixedURL = URL;
+        NSString *absoluteString = [URL absoluteString];
+        NSRange queryRange = [absoluteString rangeOfString:@"?"];
+        NSRange ampRange = [absoluteString rangeOfString:@"&"];
+        if (NSNotFound == queryRange.location && NSNotFound != ampRange.location) {
+            NSString *fixedAbsoluteString = [absoluteString stringByReplacingCharactersInRange:ampRange withString:@"?"];
+            fixedURL = [NSURL URLWithString: fixedAbsoluteString];
+        }
         NSURLComponents *components =
-            [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+            [NSURLComponents componentsWithURL:fixedURL resolvingAgainstBaseURL:NO];
         // As OAuth uses application/x-www-form-urlencoded encoding, interprets '+' as a space
         // in addition to regular percent decoding. https://url.spec.whatwg.org/#urlencoded-parsing
         components.percentEncodedQuery =


### PR DESCRIPTION
- User agent flow handles mismatched redirect urls
- For apple sign in purposes:
    - Add clientID and clientSecret to the TokenRequestBody
    - Format redirectUrl in a way that can be understood by `[NSURLComponents componentWithURL]` (replacing the first '&' with a '?' if no '?' is found)